### PR TITLE
Demote add to cart button when a custom buy now button is present

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -416,13 +416,36 @@
                   <span class="product-form__error-message"></span>
                 </div>
 
+                {%- liquid
+                  # A custom_liquid block elsewhere in this section can supply its own
+                  # filled "Buy it now" button (keyed on the custom-buy-now class). When
+                  # either that or the dynamic checkout button is present, the add to cart
+                  # button steps down to the outline style so only one button reads as primary.
+                  assign show_payment_button = false
+                  if block.settings.show_dynamic_checkout and product.selling_plan_groups == empty
+                    assign show_payment_button = true
+                  endif
+
+                  assign has_custom_buy_now = false
+                  for sibling in section.blocks
+                    if sibling.type == 'custom_liquid' and sibling.settings.custom_liquid contains 'custom-buy-now'
+                      assign has_custom_buy_now = true
+                    endif
+                  endfor
+
+                  assign demote_add_to_cart = false
+                  if show_payment_button or has_custom_buy_now
+                    assign demote_add_to_cart = true
+                  endif
+                -%}
+
                 {%- form 'product', product, data-productid: product.id, id: product_form_id, class: 'form', novalidate: 'novalidate', data-type: 'add-to-cart-form' -%}
                   <input type="hidden" name="id" data-productid="{{ product.id }}" value="{{ product.selected_or_first_available_variant.id }}" disabled>
                   <div class="product-form__buttons">
                     <button
                       type="submit"
                       name="add"
-                      class="product-form__submit button button--full-width {% if block.settings.show_dynamic_checkout and product.selling_plan_groups == empty %}button--secondary{% else %}button--primary{% endif %}"
+                      class="product-form__submit button button--full-width {% if demote_add_to_cart %}button--secondary{% else %}button--primary{% endif %}"
                     {% if product.selected_or_first_available_variant.available == false %}disabled{% endif %}
                     >
                         <span>


### PR DESCRIPTION
The buy_buttons block only checked for the dynamic checkout button when deciding between button--primary and button--secondary. On templates that supply their own filled "Buy it now" button via a custom_liquid block, both buttons rendered filled, since button--primary is a no-op class and plain .button is already the primary style.

Hoist the decision into a demote_add_to_cart variable that also accounts for a sibling custom_liquid block containing the custom-buy-now class, so only one button reads as primary.

**PR Summary:** 

_Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)._


**Why are these changes introduced?**

Fixes #0.

**What approach did you take?**

**Other considerations**

**Testing steps/scenarios**
- [ ] _List all the testing tasks that applies to your fix and help peers to review your work._

**Demo links**
_Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on._

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Notified the [help.shopify.com](https://help.shopify.com) team about updates to theme settings (current contact: Kimli)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
